### PR TITLE
[Issue#7] Support custom error keys in FormErrors via generic type parameter

### DIFF
--- a/sample-svelte/src/components/EditUsers.svelte
+++ b/sample-svelte/src/components/EditUsers.svelte
@@ -1,15 +1,15 @@
 <script lang="ts">
 	import { createForm, type Form } from "@svelte-ssv/core/form";
-	import { userSchema, type User, type UserForm } from "../lib/schemas/user";
+	import { userSchema, type User, type UserForm, type UserExtraErrors } from "../lib/schemas/user";
 
 	let users = $state<User[]>([
-		{ id: 1, name: "Alice", email: "alice@example.com", role: "Admin" },
-		{ id: 2, name: "Bob", email: "bob@example.com", role: "Editor" },
-		{ id: 3, name: "Charlie", email: "charlie@example.com", role: "Viewer" },
+		{ id: 1, name: "Alice", email: "alice@example.com", role: "Admin", age: 30 },
+		{ id: 2, name: "Bob", email: "bob@example.com", role: "Editor", age: 25 },
+		{ id: 3, name: "Charlie", email: "charlie@example.com", role: "Viewer", age: 15 },
 	]);
 
-	let form: Form<UserForm> = $state(
-		createForm(userSchema, { name: "", email: "", role: "" }),
+	let form: Form<UserForm, UserExtraErrors> = $state(
+		createForm<UserForm, UserExtraErrors>(userSchema, { name: "", email: "", role: "", age: 0 }),
 	);
 
 	let editTarget = $state<User | null>(null);
@@ -17,13 +17,13 @@
 
 	function openEdit(user: User) {
 		editTarget = user;
-		form.populate({ name: user.name, email: user.email, role: user.role });
+		form.populate({ name: user.name, email: user.email, role: user.role, age: user.age });
 		showDialog = true;
 	}
 
 	function openCreate() {
 		editTarget = null;
-		form.populate({ name: "", email: "", role: "" });
+		form.populate({ name: "", email: "", role: "", age: 0 });
 		showDialog = true;
 	}
 
@@ -54,14 +54,16 @@
 <h1>Edit Users</h1>
 <p class="description">
 	Click a user to edit. Demonstrates <code>form.populate()</code> for
-	loading existing data with clean dirty/touched state.
+	loading existing data with clean dirty/touched state.<br />
+	<strong>Custom error keys demo:</strong> Try setting Role to "Admin" with Age &lt; 18.
+	The cross-field error (<code>_adminAge</code>) appears in the banner below the form fields.
 </p>
 
 <button type="button" class="create-btn" onclick={openCreate}>+ Add User</button>
 
 <table>
 	<thead>
-		<tr><th>Name</th><th>Email</th><th>Role</th><th></th></tr>
+		<tr><th>Name</th><th>Email</th><th>Role</th><th>Age</th><th></th></tr>
 	</thead>
 	<tbody>
 		{#each users as user}
@@ -69,6 +71,7 @@
 				<td>{user.name}</td>
 				<td>{user.email}</td>
 				<td><span class="role-badge">{user.role}</span></td>
+				<td>{user.age}</td>
 				<td><button class="edit-btn" onclick={() => openEdit(user)}>Edit</button></td>
 			</tr>
 		{/each}
@@ -107,6 +110,19 @@
 					</select>
 					{#if form.touched.role && form.errors.role}<p class="error">{form.errors.role[0]}</p>{/if}
 				</div>
+
+				<div class="field">
+					<label for="age">Age {#if form.dirty.age}<span class="dirty-badge">modified</span>{/if}</label>
+					<input id="age" type="number" bind:value={form.data.age}
+						onblur={() => form.blur("age")} class:invalid={form.touched.age && form.errors.age} />
+					{#if form.touched.age && form.errors.age}<p class="error">{form.errors.age[0]}</p>{/if}
+				</div>
+
+				{#if form.errors._adminAge}
+					<div class="cross-field-error">
+						⚠️ {form.errors._adminAge[0]}
+					</div>
+				{/if}
 
 				<div class="actions">
 					<button type="submit" class="submit-btn" disabled={!form.isDirty}>
@@ -154,4 +170,5 @@
 	.reset-btn { padding: 0.5rem 1rem; background: none; border: 1px solid #d1d5db; border-radius: 8px; font-size: 0.85rem; cursor: pointer; }
 	.cancel-btn { padding: 0.5rem 1rem; background: none; border: none; font-size: 0.85rem; color: #6b7280; cursor: pointer; }
 	.dirty-notice { font-size: 0.8rem; color: #4f46e5; font-style: italic; margin-top: 0.25rem; }
+	.cross-field-error { background: #fef2f2; border: 1px solid #fecaca; color: #dc2626; padding: 0.5rem 0.75rem; border-radius: 8px; font-size: 0.85rem; margin-bottom: 0.5rem; }
 </style>

--- a/sample-svelte/src/components/RegisterForm.svelte
+++ b/sample-svelte/src/components/RegisterForm.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { createForm, type Form } from "@svelte-ssv/core/form";
-	import { registerSchema, type RegisterData } from "../lib/schemas/register";
+	import { registerSchema, type RegisterData, type RegisterExtraErrors } from "../lib/schemas/register";
 
-	let form: Form<RegisterData> = $state(
-		createForm(registerSchema, { name: "", email: "", password: "", confirmPassword: "" }),
+	let form: Form<RegisterData, RegisterExtraErrors> = $state(
+		createForm<RegisterData, RegisterExtraErrors>(registerSchema, { name: "", email: "", password: "", confirmPassword: "" }),
 	);
 	let submitted = $state(false);
 
@@ -88,6 +88,12 @@
 		{/if}
 	</div>
 
+	{#if form.errors._passwordMismatch}
+		<div class="cross-field-error">
+			⚠️ {form.errors._passwordMismatch[0]}
+		</div>
+	{/if}
+
 	<div class="actions">
 		<button type="submit" class="submit-btn">Create Account</button>
 		<button type="button" class="reset-btn" onclick={() => form.reset()} disabled={!form.isDirty}>Reset</button>
@@ -118,4 +124,5 @@
 	.dirty-notice { font-size: 0.8rem; color: #4f46e5; font-style: italic; }
 	.success-banner { background: #f0fdf4; border: 1px solid #bbf7d0; color: #16a34a; padding: 0.75rem 1rem; border-radius: 8px; margin-bottom: 1rem; display: flex; align-items: center; justify-content: space-between; font-size: 0.9rem; max-width: 400px; }
 	.success-banner button { background: none; border: none; color: #16a34a; cursor: pointer; font-weight: 600; font-size: 0.8rem; }
+	.cross-field-error { background: #fef2f2; border: 1px solid #fecaca; color: #dc2626; padding: 0.5rem 0.75rem; border-radius: 8px; font-size: 0.85rem; }
 </style>

--- a/sample-svelte/src/components/RegisterSummary.svelte
+++ b/sample-svelte/src/components/RegisterSummary.svelte
@@ -1,16 +1,17 @@
 <script lang="ts">
 	import { createForm, type Form } from "@svelte-ssv/core/form";
-	import { registerSchema, type RegisterData } from "../lib/schemas/register";
+	import { registerSchema, type RegisterData, type RegisterExtraErrors } from "../lib/schemas/register";
 
-	const fieldLabels: Record<keyof RegisterData, string> = {
+	const fieldLabels: Record<keyof RegisterData | RegisterExtraErrors, string> = {
 		name: "Name",
 		email: "Email",
 		password: "Password",
 		confirmPassword: "Confirm Password",
+		_passwordMismatch: "Password Confirmation",
 	};
 
-	let form: Form<RegisterData> = $state(
-		createForm(registerSchema, { name: "", email: "", password: "", confirmPassword: "" }),
+	let form: Form<RegisterData, RegisterExtraErrors> = $state(
+		createForm<RegisterData, RegisterExtraErrors>(registerSchema, { name: "", email: "", password: "", confirmPassword: "" }),
 	);
 	let submitted = $state(false);
 	let showSummary = $state(false);

--- a/sample-svelte/src/components/RegisterToast.svelte
+++ b/sample-svelte/src/components/RegisterToast.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
 	import { createForm, type Form } from "@svelte-ssv/core/form";
-	import { registerSchema, type RegisterData } from "../lib/schemas/register";
+	import { registerSchema, type RegisterData, type RegisterExtraErrors } from "../lib/schemas/register";
 
-	let form: Form<RegisterData> = $state(
-		createForm(registerSchema, { name: "", email: "", password: "", confirmPassword: "" }),
+	let form: Form<RegisterData, RegisterExtraErrors> = $state(
+		createForm<RegisterData, RegisterExtraErrors>(registerSchema, { name: "", email: "", password: "", confirmPassword: "" }),
 	);
 
 	// --- Toast state ---

--- a/sample-svelte/src/lib/schemas/register.ts
+++ b/sample-svelte/src/lib/schemas/register.ts
@@ -9,7 +9,7 @@ export const registerSchema = z
 	})
 	.refine((data) => data.password === data.confirmPassword, {
 		message: "Passwords do not match",
-		path: ["confirmPassword"],
+		path: ["_passwordMismatch"],
 	});
 
 export type RegisterData = {
@@ -18,3 +18,6 @@ export type RegisterData = {
 	password: string;
 	confirmPassword: string;
 };
+
+/** Extra error keys from .refine() custom paths */
+export type RegisterExtraErrors = "_passwordMismatch";

--- a/sample-svelte/src/lib/schemas/user.ts
+++ b/sample-svelte/src/lib/schemas/user.ts
@@ -1,15 +1,29 @@
 import { z } from "zod";
 
-export const userSchema = z.object({
-	name: z.string().min(1, "Name is required"),
-	email: z.string().min(1, "Email is required").email("Invalid email format"),
-	role: z.string().min(1, "Role is required"),
-});
+export const userSchema = z
+	.object({
+		name: z.string().min(1, "Name is required"),
+		email: z.string().min(1, "Email is required").email("Invalid email format"),
+		role: z.string().min(1, "Role is required"),
+		age: z
+			.number({ invalid_type_error: "Age must be a number" })
+			.int("Age must be a whole number")
+			.min(0, "Age must be 0 or older")
+			.max(150, "Age must be 150 or younger"),
+	})
+	.refine((data) => !(data.role === "Admin" && data.age < 18), {
+		message: "Admin must be at least 18 years old",
+		path: ["_adminAge"],
+	});
 
 export type UserForm = {
 	name: string;
 	email: string;
 	role: string;
+	age: number;
 };
+
+/** Extra error keys from .refine() custom paths */
+export type UserExtraErrors = "_adminAge";
 
 export type User = UserForm & { id: number };

--- a/sample-sveltekit/src/lib/schemas/register.ts
+++ b/sample-sveltekit/src/lib/schemas/register.ts
@@ -9,7 +9,7 @@ export const registerSchema = z
 	})
 	.refine((data) => data.password === data.confirmPassword, {
 		message: "Passwords do not match",
-		path: ["confirmPassword"],
+		path: ["_passwordMismatch"],
 	});
 
 export type RegisterForm = {
@@ -18,3 +18,6 @@ export type RegisterForm = {
 	password: string;
 	confirmPassword: string;
 };
+
+/** Extra error keys from .refine() custom paths */
+export type RegisterExtraErrors = "_passwordMismatch";

--- a/sample-sveltekit/src/lib/schemas/user.ts
+++ b/sample-sveltekit/src/lib/schemas/user.ts
@@ -1,15 +1,29 @@
 import { z } from "zod";
 
-export const userSchema = z.object({
-	name: z.string().min(1, "Name is required"),
-	email: z.string().min(1, "Email is required").email("Invalid email format"),
-	role: z.string().min(1, "Role is required"),
-});
+export const userSchema = z
+	.object({
+		name: z.string().min(1, "Name is required"),
+		email: z.string().min(1, "Email is required").email("Invalid email format"),
+		role: z.string().min(1, "Role is required"),
+		age: z
+			.number({ invalid_type_error: "Age must be a number" })
+			.int("Age must be a whole number")
+			.min(0, "Age must be 0 or older")
+			.max(150, "Age must be 150 or younger"),
+	})
+	.refine((data) => !(data.role === "Admin" && data.age < 18), {
+		message: "Admin must be at least 18 years old",
+		path: ["_adminAge"],
+	});
 
 export type UserForm = {
 	name: string;
 	email: string;
 	role: string;
+	age: number;
 };
+
+/** Extra error keys from .refine() custom paths */
+export type UserExtraErrors = "_adminAge";
 
 export type User = UserForm & { id: number };

--- a/sample-sveltekit/src/routes/edit/+page.svelte
+++ b/sample-sveltekit/src/routes/edit/+page.svelte
@@ -1,16 +1,16 @@
 <script lang="ts">
 	import { createForm } from "@svelte-ssv/core/form";
-	import { userSchema, type User, type UserForm } from "$lib/schemas/user";
+	import { userSchema, type User, type UserForm, type UserExtraErrors } from "$lib/schemas/user";
 
 	// Mock data — in a real app this would come from a server load function
 	let users = $state<User[]>([
-		{ id: 1, name: "Alice", email: "alice@example.com", role: "Admin" },
-		{ id: 2, name: "Bob", email: "bob@example.com", role: "Editor" },
-		{ id: 3, name: "Charlie", email: "charlie@example.com", role: "Viewer" },
+		{ id: 1, name: "Alice", email: "alice@example.com", role: "Admin", age: 30 },
+		{ id: 2, name: "Bob", email: "bob@example.com", role: "Editor", age: 25 },
+		{ id: 3, name: "Charlie", email: "charlie@example.com", role: "Viewer", age: 15 },
 	]);
 
 	let form = $state(
-		createForm(userSchema, { name: "", email: "", role: "" }),
+		createForm<UserForm, UserExtraErrors>(userSchema, { name: "", email: "", role: "", age: 0 }),
 	);
 
 	let editTarget = $state<User | null>(null);
@@ -18,13 +18,13 @@
 
 	function openEdit(user: User) {
 		editTarget = user;
-		form.populate({ name: user.name, email: user.email, role: user.role });
+		form.populate({ name: user.name, email: user.email, role: user.role, age: user.age });
 		showDialog = true;
 	}
 
 	function openCreate() {
 		editTarget = null;
-		form.populate({ name: "", email: "", role: "" });
+		form.populate({ name: "", email: "", role: "", age: 0 });
 		showDialog = true;
 	}
 
@@ -57,7 +57,9 @@
 <h1>Edit Users <span class="badge">populate()</span></h1>
 <p class="description">
 	Click a user to edit. Demonstrates <code>form.populate()</code> for
-	loading existing data into the form with clean dirty/touched state.
+	loading existing data with clean dirty/touched state.<br />
+	<strong>Custom error keys demo:</strong> Try setting Role to "Admin" with Age &lt; 18.
+	The cross-field error (<code>_adminAge</code>) appears in the banner below the form fields.
 </p>
 
 <button type="button" class="create-btn" onclick={openCreate}>
@@ -70,6 +72,7 @@
 			<th>Name</th>
 			<th>Email</th>
 			<th>Role</th>
+			<th>Age</th>
 			<th></th>
 		</tr>
 	</thead>
@@ -79,6 +82,7 @@
 				<td>{user.name}</td>
 				<td>{user.email}</td>
 				<td><span class="role-badge">{user.role}</span></td>
+				<td>{user.age}</td>
 				<td>
 					<button class="edit-btn" onclick={() => openEdit(user)}>Edit</button>
 				</td>
@@ -140,6 +144,26 @@
 						<p class="error">{form.errors.role[0]}</p>
 					{/if}
 				</div>
+
+				<div class="field">
+					<label for="age">
+						Age
+						{#if form.dirty.age}<span class="dirty-badge">modified</span>{/if}
+					</label>
+					<input id="age" type="number" bind:value={form.data.age}
+						onblur={() => form.blur("age")}
+						class:invalid={form.touched.age && form.errors.age}
+					/>
+					{#if form.touched.age && form.errors.age}
+						<p class="error">{form.errors.age[0]}</p>
+					{/if}
+				</div>
+
+				{#if form.errors._adminAge}
+					<div class="cross-field-error">
+						⚠️ {form.errors._adminAge[0]}
+					</div>
+				{/if}
 
 				<div class="actions">
 					<button type="submit" class="submit-btn" disabled={!form.isDirty}>
@@ -216,6 +240,7 @@
 	.reset-btn:disabled { opacity: 0.4; cursor: default; }
 	.cancel-btn { padding: 0.5rem 1rem; background: none; border: none; font-size: 0.85rem; color: var(--color-text-muted); cursor: pointer; }
 	.dirty-notice { font-size: 0.8rem; color: var(--color-primary); font-style: italic; margin-top: 0.25rem; }
+	.cross-field-error { background: #fef2f2; border: 1px solid #fecaca; color: var(--color-error); padding: 0.5rem 0.75rem; border-radius: var(--radius); font-size: 0.85rem; margin-bottom: 0.5rem; }
 
 	.code-note { margin-top: 2rem; padding: 1rem 1.5rem; background: var(--color-surface); border: 1px solid var(--color-border); border-radius: var(--radius); max-width: 600px; }
 	.code-note h2 { font-size: 0.95rem; margin-bottom: 0.5rem; }

--- a/sample-sveltekit/src/routes/register-summary/+page.server.ts
+++ b/sample-sveltekit/src/routes/register-summary/+page.server.ts
@@ -1,9 +1,9 @@
 import type { Actions } from "./$types";
 import { fail } from "@sveltejs/kit";
 import { createFormValidator } from "@svelte-ssv/core";
-import { registerSchema } from "$lib/schemas/register";
+import { registerSchema, type RegisterForm, type RegisterExtraErrors } from "$lib/schemas/register";
 
-const validator = createFormValidator(registerSchema);
+const validator = createFormValidator<RegisterForm, RegisterExtraErrors>(registerSchema);
 
 export const actions = {
 	default: async ({ request }) => {

--- a/sample-sveltekit/src/routes/register-summary/+page.svelte
+++ b/sample-sveltekit/src/routes/register-summary/+page.svelte
@@ -2,17 +2,18 @@
 	import { enhance } from "$app/forms";
 	import { createForm } from "@svelte-ssv/core/form";
 	import { createEnhanceHandler } from "@svelte-ssv/core/enhance";
-	import { registerSchema, type RegisterForm } from "$lib/schemas/register";
+	import { registerSchema, type RegisterForm, type RegisterExtraErrors } from "$lib/schemas/register";
 
-	const fieldLabels: Record<keyof RegisterForm, string> = {
+	const fieldLabels: Record<keyof RegisterForm | RegisterExtraErrors, string> = {
 		name: "Name",
 		email: "Email",
 		password: "Password",
 		confirmPassword: "Confirm Password",
+		_passwordMismatch: "Password Confirmation",
 	};
 
 	let form = $state(
-		createForm(registerSchema, {
+		createForm<RegisterForm, RegisterExtraErrors>(registerSchema, {
 			name: "",
 			email: "",
 			password: "",

--- a/sample-sveltekit/src/routes/register-toast/+page.server.ts
+++ b/sample-sveltekit/src/routes/register-toast/+page.server.ts
@@ -1,9 +1,9 @@
 import type { Actions } from "./$types";
 import { fail } from "@sveltejs/kit";
 import { createFormValidator } from "@svelte-ssv/core";
-import { registerSchema } from "$lib/schemas/register";
+import { registerSchema, type RegisterForm, type RegisterExtraErrors } from "$lib/schemas/register";
 
-const validator = createFormValidator(registerSchema);
+const validator = createFormValidator<RegisterForm, RegisterExtraErrors>(registerSchema);
 
 export const actions = {
 	default: async ({ request }) => {

--- a/sample-sveltekit/src/routes/register-toast/+page.svelte
+++ b/sample-sveltekit/src/routes/register-toast/+page.svelte
@@ -2,10 +2,10 @@
 	import { enhance } from "$app/forms";
 	import { createForm } from "@svelte-ssv/core/form";
 	import { createEnhanceHandler } from "@svelte-ssv/core/enhance";
-	import { registerSchema } from "$lib/schemas/register";
+	import { registerSchema, type RegisterForm, type RegisterExtraErrors } from "$lib/schemas/register";
 
 	let form = $state(
-		createForm(registerSchema, {
+		createForm<RegisterForm, RegisterExtraErrors>(registerSchema, {
 			name: "",
 			email: "",
 			password: "",

--- a/sample-sveltekit/src/routes/register/+page.server.ts
+++ b/sample-sveltekit/src/routes/register/+page.server.ts
@@ -1,9 +1,9 @@
 import type { Actions } from "./$types";
 import { fail } from "@sveltejs/kit";
 import { createFormValidator } from "@svelte-ssv/core";
-import { registerSchema } from "$lib/schemas/register";
+import { registerSchema, type RegisterForm, type RegisterExtraErrors } from "$lib/schemas/register";
 
-const validator = createFormValidator(registerSchema);
+const validator = createFormValidator<RegisterForm, RegisterExtraErrors>(registerSchema);
 
 export const actions = {
 	default: async ({ request }) => {

--- a/sample-sveltekit/src/routes/register/+page.svelte
+++ b/sample-sveltekit/src/routes/register/+page.svelte
@@ -2,12 +2,12 @@
 	import { enhance } from "$app/forms";
 	import { createForm } from "@svelte-ssv/core/form";
 	import { buildEnhanceHandler } from "@svelte-ssv/core/enhance";
-	import { registerSchema } from "$lib/schemas/register";
+	import { registerSchema, type RegisterForm, type RegisterExtraErrors } from "$lib/schemas/register";
 
 	let submitted = $state(false);
 
 	let form = $state(
-		createForm(registerSchema, {
+		createForm<RegisterForm, RegisterExtraErrors>(registerSchema, {
 			name: "",
 			email: "",
 			password: "",
@@ -71,6 +71,10 @@
 		{#if form.touched.confirmPassword && form.errors.confirmPassword}<p class="error">{form.errors.confirmPassword[0]}</p>{/if}
 	</div>
 
+	{#if form.errors._passwordMismatch}
+		<div class="cross-field-error">⚠️ {form.errors._passwordMismatch[0]}</div>
+	{/if}
+
 	{#if form.errors._form}
 		<p class="error form-error">{form.errors._form[0]}</p>
 	{/if}
@@ -95,6 +99,7 @@
 	input.invalid { border-color: var(--color-error); }
 	.error { color: var(--color-error); font-size: 0.8rem; }
 	.form-error { padding: 0.5rem 0.75rem; background: #fef2f2; border: 1px solid #fecaca; border-radius: var(--radius); }
+	.cross-field-error { background: #fef2f2; border: 1px solid #fecaca; color: var(--color-error); padding: 0.5rem 0.75rem; border-radius: var(--radius); font-size: 0.85rem; }
 	.actions { display: flex; gap: 0.75rem; }
 	.submit-btn { padding: 0.6rem 1.2rem; background: var(--color-primary); color: white; border: none; border-radius: var(--radius); font-size: 0.9rem; font-weight: 600; cursor: pointer; }
 	.submit-btn:hover { background: var(--color-primary-hover); }

--- a/src/core/validator.test.ts
+++ b/src/core/validator.test.ts
@@ -265,6 +265,97 @@ describe("cross-field validation", () => {
 });
 
 // ---------------------------------------------------------------
+// Custom error keys (extra keys via E type parameter)
+// ---------------------------------------------------------------
+
+describe("custom error keys", () => {
+	const groupSchema = z
+		.object({
+			kbId: z.string().optional(),
+			kbName: z.string().optional(),
+			kbRegion: z.string().optional(),
+		})
+		.refine(
+			(data) => {
+				const fields = [data.kbId, data.kbName, data.kbRegion];
+				const filled = fields.filter(Boolean).length;
+				return filled === 0 || filled === 3;
+			},
+			{
+				message: "All fields must be filled or all must be empty",
+				path: ["_kbGroup"],
+			},
+		);
+
+	type GroupForm = z.infer<typeof groupSchema>;
+
+	const validator = createFormValidator<GroupForm, "_kbGroup">(groupSchema);
+
+	it("assigns custom path errors to the extra key", () => {
+		const result = validator.validate({
+			kbId: "id1",
+			kbName: undefined,
+			kbRegion: undefined,
+		});
+		expect(result.valid).toBe(false);
+		expect(result.errors._kbGroup).toContain("All fields must be filled or all must be empty");
+	});
+
+	it("returns no custom key errors when validation passes", () => {
+		const result = validator.validate({
+			kbId: undefined,
+			kbName: undefined,
+			kbRegion: undefined,
+		});
+		expect(result.valid).toBe(true);
+		expect(result.errors._kbGroup).toBeUndefined();
+	});
+
+	it("retrieves custom key errors via validateField", () => {
+		const result = validator.validateField("_kbGroup", {
+			kbId: "id1",
+			kbName: undefined,
+			kbRegion: undefined,
+		});
+		expect(result.errors._kbGroup).toContain("All fields must be filled or all must be empty");
+	});
+
+	it("mergeFieldErrors works with custom keys", () => {
+		const current = { kbId: ["Some error"] } as ReturnType<typeof validator.validate>["errors"];
+		const fieldResult = validator.validateField("_kbGroup", {
+			kbId: "id1",
+			kbName: undefined,
+			kbRegion: undefined,
+		});
+		const merged = validator.mergeFieldErrors(current, "_kbGroup", fieldResult);
+		expect(merged.kbId).toEqual(["Some error"]);
+		expect(merged._kbGroup).toContain("All fields must be filled or all must be empty");
+	});
+
+	it("mergeFieldErrors removes custom key errors when resolved", () => {
+		const current = {
+			_kbGroup: ["All fields must be filled or all must be empty"],
+		} as ReturnType<typeof validator.validate>["errors"];
+		const fieldResult = validator.validateField("_kbGroup", {
+			kbId: undefined,
+			kbName: undefined,
+			kbRegion: undefined,
+		});
+		const merged = validator.mergeFieldErrors(current, "_kbGroup", fieldResult);
+		expect(merged._kbGroup).toBeUndefined();
+	});
+
+	it("parseErrors maps custom path keys correctly", () => {
+		const errors = validator.parseErrors([
+			{ path: ["_kbGroup"], message: "Group error" },
+			{ path: ["kbId"], message: "Field error" },
+		]);
+		expect(errors._kbGroup).toEqual(["Group error"]);
+		expect(errors.kbId).toEqual(["Field error"]);
+	});
+});
+
+// ---------------------------------------------------------------
 // Standard Schema V1 support
 // ---------------------------------------------------------------
 

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -283,6 +283,14 @@ function createValidateFn<T>(
  *   <p class="text-red-600">{errors.name[0]}</p>
  * {/if}
  * ```
+ *
+ * @example Custom error keys for cross-field validation
+ * ```typescript
+ * // When using Zod .refine() with a custom path not in the schema,
+ * // pass the extra key as the second type parameter:
+ * const validator = createFormValidator<MyForm, '_groupError'>(schema);
+ * // validator.validate(...).errors._groupError is now type-safe
+ * ```
  */
 export function createFormValidator<T extends Record<string, unknown>, E extends string = never>(
 	schema: SchemaInput<T>,

--- a/src/core/validator.ts
+++ b/src/core/validator.ts
@@ -94,35 +94,47 @@ export type SchemaInput<T = unknown> = StandardSchema<T> | ZodSchema<T>;
  *
  * The `_form` key is reserved for form-level errors (not associated with a specific field).
  *
+ * The optional second type parameter `E` allows declaring additional error keys
+ * for custom validation paths (e.g., Zod's `.refine()` with a `path` that does
+ * not correspond to any schema field).
+ *
  * @example
  * ```typescript
+ * // Basic usage
  * const errors: FormErrors<{ name: string; email: string }> = {
  *   name: ['Name is required'],
  *   _form: ['A server error occurred'],
  * };
+ *
+ * // With custom error keys
+ * const errors: FormErrors<{ kbId?: string; kbName?: string }, '_kbGroup'> = {
+ *   _kbGroup: ['All fields must be filled or all must be empty'],
+ * };
  * ```
  */
-export type FormErrors<T extends Record<string, unknown> = Record<string, unknown>> = {
+export type FormErrors<T extends Record<string, unknown> = Record<string, unknown>, E extends string = never> = {
 	[K in keyof T]?: string[];
 } & {
 	/** Form-level errors (not associated with a specific field) */
 	_form?: string[];
+} & {
+	[K in E]?: string[];
 };
 
 /**
  * Validation result.
  */
-export type ValidationResult<T extends Record<string, unknown>> =
-	| { valid: true; data: T; errors: FormErrors<T> }
-	| { valid: false; data: undefined; errors: FormErrors<T> };
+export type ValidationResult<T extends Record<string, unknown>, E extends string = never> =
+	| { valid: true; data: T; errors: FormErrors<T, E> }
+	| { valid: false; data: undefined; errors: FormErrors<T, E> };
 
 /**
  * Field validation result.
  *
  * Contains only the errors for the specified field. Empty object if no errors.
  */
-export type FieldValidationResult<T extends Record<string, unknown>> = {
-	errors: FormErrors<T>;
+export type FieldValidationResult<T extends Record<string, unknown>, E extends string = never> = {
+	errors: FormErrors<T, E>;
 };
 
 /**
@@ -131,9 +143,9 @@ export type FieldValidationResult<T extends Record<string, unknown>> = {
  * Provides validation functionality from any supported schema.
  * Framework-agnostic — works with Svelte, React, Vue, or any other framework.
  */
-export type FormValidator<T extends Record<string, unknown>> = {
+export type FormValidator<T extends Record<string, unknown>, E extends string = never> = {
 	/** Validate the entire form */
-	validate: (data: Record<string, unknown>) => ValidationResult<T>;
+	validate: (data: Record<string, unknown>) => ValidationResult<T, E>;
 
 	/**
 	 * Validate a single field (for onblur / oninput handlers).
@@ -141,7 +153,7 @@ export type FormValidator<T extends Record<string, unknown>> = {
 	 * Validates the entire form data and extracts only the errors
 	 * for the specified field. This ensures cross-field validations work correctly.
 	 */
-	validateField: (field: keyof T & string, data: Record<string, unknown>) => FieldValidationResult<T>;
+	validateField: (field: (keyof T & string) | E, data: Record<string, unknown>) => FieldValidationResult<T, E>;
 
 	/**
 	 * Convert validation issues into field-indexed FormErrors.
@@ -149,10 +161,10 @@ export type FormValidator<T extends Record<string, unknown>> = {
 	 * Accepts either a flat array of issues (Standard Schema style) or
 	 * an object with an `issues` property (Zod error style) for backward compatibility.
 	 */
-	parseErrors: (issuesOrError: readonly StandardIssue[] | { issues: readonly StandardIssue[] }) => FormErrors<T>;
+	parseErrors: (issuesOrError: readonly StandardIssue[] | { issues: readonly StandardIssue[] }) => FormErrors<T, E>;
 
 	/** Create a form-level error from a server error message */
-	setServerError: (message: string) => FormErrors<T>;
+	setServerError: (message: string) => FormErrors<T, E>;
 
 	/**
 	 * Merge field validation results into existing errors.
@@ -160,10 +172,10 @@ export type FormValidator<T extends Record<string, unknown>> = {
 	 * Used for real-time validation to update only the field being edited.
 	 */
 	mergeFieldErrors: (
-		current: FormErrors<T>,
-		field: keyof T & string,
-		fieldResult: FieldValidationResult<T>,
-	) => FormErrors<T>;
+		current: FormErrors<T, E>,
+		field: (keyof T & string) | E,
+		fieldResult: FieldValidationResult<T, E>,
+	) => FormErrors<T, E>;
 };
 
 // ---------------------------------------------------------------------------
@@ -272,14 +284,18 @@ function createValidateFn<T>(
  * {/if}
  * ```
  */
-export function createFormValidator<T extends Record<string, unknown>>(schema: SchemaInput<T>): FormValidator<T> {
+export function createFormValidator<T extends Record<string, unknown>, E extends string = never>(
+	schema: SchemaInput<T>,
+): FormValidator<T, E> {
 	const doValidate = createValidateFn(schema);
 
-	function parseErrors(issuesOrError: readonly StandardIssue[] | { issues: readonly StandardIssue[] }): FormErrors<T> {
+	function parseErrors(
+		issuesOrError: readonly StandardIssue[] | { issues: readonly StandardIssue[] },
+	): FormErrors<T, E> {
 		const issues = Array.isArray(issuesOrError)
 			? issuesOrError
 			: (issuesOrError as { issues: readonly StandardIssue[] }).issues;
-		const errors: FormErrors<T> = {} as FormErrors<T>;
+		const errors: FormErrors<T, E> = {} as FormErrors<T, E>;
 		for (const issue of issues) {
 			const firstSegment = issue.path?.[0];
 			if (firstSegment == null) {
@@ -287,25 +303,24 @@ export function createFormValidator<T extends Record<string, unknown>>(schema: S
 				errors._form.push(issue.message);
 				continue;
 			}
-			const field = resolvePathSegment(firstSegment) as keyof T | undefined;
+			const field = resolvePathSegment(firstSegment);
 			if (field) {
-				const fieldErrors = errors[field];
-				if (!fieldErrors) {
-					(errors as Record<string, string[]>)[field as string] = [];
+				if (!(errors as Record<string, string[]>)[field]) {
+					(errors as Record<string, string[]>)[field] = [];
 				}
-				(errors[field] as string[]).push(issue.message);
+				(errors as Record<string, string[]>)[field].push(issue.message);
 			}
 		}
 		return errors;
 	}
 
-	function validate(data: Record<string, unknown>): ValidationResult<T> {
+	function validate(data: Record<string, unknown>): ValidationResult<T, E> {
 		const result = doValidate(data);
 		if (result.ok) {
 			return {
 				valid: true,
 				data: result.data,
-				errors: {} as FormErrors<T>,
+				errors: {} as FormErrors<T, E>,
 			};
 		}
 		return {
@@ -315,10 +330,10 @@ export function createFormValidator<T extends Record<string, unknown>>(schema: S
 		};
 	}
 
-	function validateField(field: keyof T & string, data: Record<string, unknown>): FieldValidationResult<T> {
+	function validateField(field: (keyof T & string) | E, data: Record<string, unknown>): FieldValidationResult<T, E> {
 		const result = doValidate(data);
 		if (result.ok) {
-			return { errors: {} as FormErrors<T> };
+			return { errors: {} as FormErrors<T, E> };
 		}
 
 		// Extract only the errors for the specified field
@@ -333,29 +348,29 @@ export function createFormValidator<T extends Record<string, unknown>>(schema: S
 		}
 
 		if (fieldErrors.length === 0) {
-			return { errors: {} as FormErrors<T> };
+			return { errors: {} as FormErrors<T, E> };
 		}
 
 		return {
-			errors: { [field]: fieldErrors } as unknown as FormErrors<T>,
+			errors: { [field]: fieldErrors } as unknown as FormErrors<T, E>,
 		};
 	}
 
-	function setServerError(message: string): FormErrors<T> {
-		return { _form: [message] } as FormErrors<T>;
+	function setServerError(message: string): FormErrors<T, E> {
+		return { _form: [message] } as FormErrors<T, E>;
 	}
 
 	function mergeFieldErrors(
-		current: FormErrors<T>,
-		field: keyof T & string,
-		fieldResult: FieldValidationResult<T>,
-	): FormErrors<T> {
+		current: FormErrors<T, E>,
+		field: (keyof T & string) | E,
+		fieldResult: FieldValidationResult<T, E>,
+	): FormErrors<T, E> {
 		const merged = { ...current };
-		const fieldErrors = fieldResult.errors[field];
+		const fieldErrors = (fieldResult.errors as Record<string, string[]>)[field as string];
 		if (fieldErrors && fieldErrors.length > 0) {
-			(merged as Record<string, string[]>)[field] = fieldErrors;
+			(merged as Record<string, string[]>)[field as string] = fieldErrors;
 		} else {
-			delete merged[field];
+			delete (merged as Record<string, string[]>)[field as string];
 		}
 		return merged;
 	}

--- a/src/enhance/enhance-form.ts
+++ b/src/enhance/enhance-form.ts
@@ -72,13 +72,13 @@ export type BuildEnhanceOptions = {
  * @param options - Callback options
  * @returns A function to pass to SvelteKit's `use:enhance`
  */
-export function buildEnhanceHandler<T extends Record<string, unknown>>(
-	form: Form<T>,
+export function buildEnhanceHandler<T extends Record<string, unknown>, E extends string = never>(
+	form: Form<T, E>,
 	options?: BuildEnhanceOptions,
-): ReturnType<typeof createEnhanceHandler<T>> {
-	return createEnhanceHandler(form.validator, {
+): ReturnType<typeof createEnhanceHandler<T, E>> {
+	return createEnhanceHandler<T, E>(form.validator, {
 		getData: () => form.data,
-		setErrors: (e: FormErrors<T>) => {
+		setErrors: (e: FormErrors<T, E>) => {
 			const keys = Object.keys(form.data) as (keyof T & string)[];
 			for (const key of keys) {
 				form.touched[key] = true;

--- a/src/enhance/enhance.test.ts
+++ b/src/enhance/enhance.test.ts
@@ -146,6 +146,66 @@ describe("createEnhanceHandler", () => {
 });
 
 // ---------------------------------------------------------------
+// createEnhanceHandler — custom error keys
+// ---------------------------------------------------------------
+
+describe("createEnhanceHandler with custom error keys", () => {
+	const groupSchema = z
+		.object({
+			kbId: z.string().optional(),
+			kbName: z.string().optional(),
+			kbRegion: z.string().optional(),
+		})
+		.refine(
+			(data) => {
+				const fields = [data.kbId, data.kbName, data.kbRegion];
+				const filled = fields.filter(Boolean).length;
+				return filled === 0 || filled === 3;
+			},
+			{
+				message: "All fields must be filled or all must be empty",
+				path: ["_kbGroup"],
+			},
+		);
+
+	type GroupForm = z.infer<typeof groupSchema>;
+
+	const validator = createFormValidator<GroupForm, "_kbGroup">(groupSchema);
+
+	it("surfaces custom key errors on validation failure", () => {
+		const setErrors = vi.fn();
+		const handler = createEnhanceHandler(validator, {
+			getData: () => ({ kbId: "id1", kbName: undefined, kbRegion: undefined }),
+			setErrors,
+		});
+
+		const input = createMockInput();
+		handler(input);
+
+		expect(input.cancel).toHaveBeenCalled();
+		expect(setErrors).toHaveBeenCalledWith(
+			expect.objectContaining({
+				_kbGroup: expect.arrayContaining(["All fields must be filled or all must be empty"]),
+			}),
+		);
+	});
+
+	it("clears errors on successful validation with custom keys", () => {
+		const setErrors = vi.fn();
+		const handler = createEnhanceHandler(validator, {
+			getData: () => ({ kbId: undefined, kbName: undefined, kbRegion: undefined }),
+			setErrors,
+		});
+
+		const input = createMockInput();
+		handler(input);
+
+		expect(input.cancel).not.toHaveBeenCalled();
+		expect(setErrors).toHaveBeenCalledWith({});
+	});
+});
+
+// ---------------------------------------------------------------
 // buildEnhanceHandler
 // ---------------------------------------------------------------
 
@@ -215,6 +275,62 @@ describe("buildEnhanceHandler", () => {
 		const result = handler(input);
 
 		// Should pass validation since data was updated
+		expect(input.cancel).not.toHaveBeenCalled();
+		expect(result).toBeDefined();
+	});
+});
+
+// ---------------------------------------------------------------
+// buildEnhanceHandler — custom error keys
+// ---------------------------------------------------------------
+
+describe("buildEnhanceHandler with custom error keys", () => {
+	const groupSchema = z
+		.object({
+			kbId: z.string().optional(),
+			kbName: z.string().optional(),
+			kbRegion: z.string().optional(),
+		})
+		.refine(
+			(data) => {
+				const fields = [data.kbId, data.kbName, data.kbRegion];
+				const filled = fields.filter(Boolean).length;
+				return filled === 0 || filled === 3;
+			},
+			{
+				message: "All fields must be filled or all must be empty",
+				path: ["_kbGroup"],
+			},
+		);
+
+	type GroupForm = z.infer<typeof groupSchema>;
+
+	it("cancels on custom key validation failure and sets errors", () => {
+		const form = createForm<GroupForm, "_kbGroup">(groupSchema, {
+			kbId: "id1",
+			kbName: undefined,
+			kbRegion: undefined,
+		});
+		const handler = buildEnhanceHandler(form);
+
+		const input = createMockInput();
+		handler(input);
+
+		expect(input.cancel).toHaveBeenCalled();
+		expect(form.errors._kbGroup).toContain("All fields must be filled or all must be empty");
+	});
+
+	it("passes validation when all group fields are empty", () => {
+		const form = createForm<GroupForm, "_kbGroup">(groupSchema, {
+			kbId: undefined,
+			kbName: undefined,
+			kbRegion: undefined,
+		});
+		const handler = buildEnhanceHandler(form);
+
+		const input = createMockInput();
+		const result = handler(input);
+
 		expect(input.cancel).not.toHaveBeenCalled();
 		expect(result).toBeDefined();
 	});

--- a/src/enhance/enhance.ts
+++ b/src/enhance/enhance.ts
@@ -38,12 +38,12 @@ import type { FormErrors, FormValidator } from "../core/validator";
 /**
  * Options for `createEnhanceHandler`.
  */
-export type EnhanceHandlerOptions<T extends Record<string, unknown>> = {
+export type EnhanceHandlerOptions<T extends Record<string, unknown>, E extends string = never> = {
 	/** Function that returns the current form data */
 	getData: () => T;
 
 	/** Function to update the error state */
-	setErrors: (errors: FormErrors<T>) => void;
+	setErrors: (errors: FormErrors<T, E>) => void;
 
 	/** Callback on successful submission (e.g., close modal) */
 	onSuccess?: () => void;
@@ -66,9 +66,9 @@ export type EnhanceHandlerOptions<T extends Record<string, unknown>> = {
  * @param options - Callback options
  * @returns A function to pass to SvelteKit's `use:enhance`
  */
-export function createEnhanceHandler<T extends Record<string, unknown>>(
-	validator: FormValidator<T>,
-	options: EnhanceHandlerOptions<T>,
+export function createEnhanceHandler<T extends Record<string, unknown>, E extends string = never>(
+	validator: FormValidator<T, E>,
+	options: EnhanceHandlerOptions<T, E>,
 ): (input: {
 	cancel: () => void;
 	formData: FormData;
@@ -102,7 +102,7 @@ export function createEnhanceHandler<T extends Record<string, unknown>>(
 			cancel();
 			return;
 		}
-		options.setErrors({} as FormErrors<T>);
+		options.setErrors({} as FormErrors<T, E>);
 
 		// Post-submission handler
 		return async ({ update, result: actionResult }) => {

--- a/src/form/form.test.ts
+++ b/src/form/form.test.ts
@@ -288,6 +288,67 @@ describe("createForm", () => {
 	});
 
 	// ---------------------------------------------------------------
+	// Custom error keys (extra keys via E type parameter)
+	// ---------------------------------------------------------------
+
+	describe("custom error keys", () => {
+		const groupSchema = z
+			.object({
+				kbId: z.string().optional(),
+				kbName: z.string().optional(),
+				kbRegion: z.string().optional(),
+			})
+			.refine(
+				(data) => {
+					const fields = [data.kbId, data.kbName, data.kbRegion];
+					const filled = fields.filter(Boolean).length;
+					return filled === 0 || filled === 3;
+				},
+				{
+					message: "All fields must be filled or all must be empty",
+					path: ["_kbGroup"],
+				},
+			);
+
+		type GroupForm = z.infer<typeof groupSchema>;
+		const groupInitial: GroupForm = { kbId: undefined, kbName: undefined, kbRegion: undefined };
+
+		it("validate captures custom path errors in form.errors", () => {
+			const form = createForm<GroupForm, "_kbGroup">(groupSchema, groupInitial);
+			form.data.kbId = "id1";
+			const result = form.validate();
+
+			expect(result.valid).toBe(false);
+			expect(form.errors._kbGroup).toContain("All fields must be filled or all must be empty");
+		});
+
+		it("validate clears custom path errors when valid", () => {
+			const form = createForm<GroupForm, "_kbGroup">(groupSchema, groupInitial);
+			form.data.kbId = "id1";
+			form.validate();
+			expect(form.errors._kbGroup).toBeDefined();
+
+			// Fix: fill all fields
+			form.data.kbName = "name1";
+			form.data.kbRegion = "region1";
+			const result = form.validate();
+
+			expect(result.valid).toBe(true);
+			expect(form.errors._kbGroup).toBeUndefined();
+		});
+
+		it("reset clears custom path errors", () => {
+			const form = createForm<GroupForm, "_kbGroup">(groupSchema, groupInitial);
+			form.data.kbId = "id1";
+			form.validate();
+			expect(form.errors._kbGroup).toBeDefined();
+
+			form.reset();
+			expect(form.errors._kbGroup).toBeUndefined();
+		});
+	});
+
+	// ---------------------------------------------------------------
 	// populate
 	// ---------------------------------------------------------------
 

--- a/src/form/form.ts
+++ b/src/form/form.ts
@@ -121,6 +121,16 @@ export type Form<T extends Record<string, unknown>, E extends string = never> = 
  * @param schema - A Standard Schema V1 or Zod-compatible schema
  * @param initial - Initial form data
  * @returns A `Form<T>` object
+ *
+ * @example Custom error keys for cross-field validation
+ * ```typescript
+ * // When using Zod .refine() with a custom path (e.g., path: ["_kbGroup"]),
+ * // pass the extra key as the second type parameter so form.errors._kbGroup
+ * // is type-safe. TypeScript cannot infer E from the schema, so it must be
+ * // specified explicitly:
+ * type MyForm = z.infer<typeof schema>;
+ * let form = $state(createForm<MyForm, '_kbGroup'>(schema, initial));
+ * ```
  */
 export function createForm<T extends Record<string, unknown>, E extends string = never>(
 	schema: SchemaInput<T>,

--- a/src/form/form.ts
+++ b/src/form/form.ts
@@ -39,13 +39,17 @@ import { createFormValidator } from "../core/validator";
  *
  * Holds reactive data, errors, touched/dirty tracking, and provides
  * methods for validation, blur handling, and reset.
+ *
+ * The optional second type parameter `E` allows declaring additional error keys
+ * for custom validation paths (e.g., Zod's `.refine()` with a `path` that does
+ * not correspond to any schema field).
  */
-export type Form<T extends Record<string, unknown>> = {
+export type Form<T extends Record<string, unknown>, E extends string = never> = {
 	/** Current form data (mutable, bind-friendly) */
 	data: T;
 
 	/** Current validation errors */
-	errors: FormErrors<T>;
+	errors: FormErrors<T, E>;
 
 	/** Per-field touched state (set to `true` on blur) */
 	touched: { [K in keyof T]: boolean };
@@ -57,7 +61,7 @@ export type Form<T extends Record<string, unknown>> = {
 	readonly isDirty: boolean;
 
 	/** The underlying FormValidator (useful for `createEnhanceHandler`) */
-	readonly validator: FormValidator<T>;
+	readonly validator: FormValidator<T, E>;
 
 	/**
 	 * Mark a field as touched, update dirty state, and run field validation.
@@ -71,7 +75,7 @@ export type Form<T extends Record<string, unknown>> = {
 	 *
 	 * Marks all fields as touched so that errors become visible.
 	 */
-	validate: () => ValidationResult<T>;
+	validate: () => ValidationResult<T, E>;
 
 	/** Reset form to its initial state (data, errors, touched, dirty). */
 	reset: () => void;
@@ -118,8 +122,11 @@ export type Form<T extends Record<string, unknown>> = {
  * @param initial - Initial form data
  * @returns A `Form<T>` object
  */
-export function createForm<T extends Record<string, unknown>>(schema: SchemaInput<T>, initial: T): Form<T> {
-	const _validator = createFormValidator(schema);
+export function createForm<T extends Record<string, unknown>, E extends string = never>(
+	schema: SchemaInput<T>,
+	initial: T,
+): Form<T, E> {
+	const _validator = createFormValidator<T, E>(schema);
 	const _initialData = structuredClone(initial);
 	const keys = Object.keys(initial) as (keyof T & string)[];
 
@@ -132,7 +139,7 @@ export function createForm<T extends Record<string, unknown>>(schema: SchemaInpu
 
 	return {
 		data: structuredClone(initial),
-		errors: {} as FormErrors<T>,
+		errors: {} as FormErrors<T, E>,
 		touched,
 		dirty,
 
@@ -140,7 +147,7 @@ export function createForm<T extends Record<string, unknown>>(schema: SchemaInpu
 			return keys.some((key) => this.data[key] !== _initialData[key]);
 		},
 
-		get validator(): FormValidator<T> {
+		get validator(): FormValidator<T, E> {
 			return _validator;
 		},
 
@@ -152,7 +159,7 @@ export function createForm<T extends Record<string, unknown>>(schema: SchemaInpu
 			this.errors = _validator.mergeFieldErrors(this.errors, field, result);
 		},
 
-		validate(): ValidationResult<T> {
+		validate(): ValidationResult<T, E> {
 			// Mark all fields as touched and update dirty state
 			for (const key of keys) {
 				this.touched[key] = true;
@@ -160,7 +167,7 @@ export function createForm<T extends Record<string, unknown>>(schema: SchemaInpu
 			}
 
 			const result = _validator.validate(this.data as Record<string, unknown>);
-			this.errors = result.valid ? ({} as FormErrors<T>) : result.errors;
+			this.errors = result.valid ? ({} as FormErrors<T, E>) : result.errors;
 			return result;
 		},
 
@@ -171,7 +178,7 @@ export function createForm<T extends Record<string, unknown>>(schema: SchemaInpu
 				this.touched[key] = false;
 				this.dirty[key] = false;
 			}
-			this.errors = {} as FormErrors<T>;
+			this.errors = {} as FormErrors<T, E>;
 		},
 
 		populate(newData: Partial<T>): void {
@@ -184,7 +191,7 @@ export function createForm<T extends Record<string, unknown>>(schema: SchemaInpu
 				this.touched[key] = false;
 				this.dirty[key] = false;
 			}
-			this.errors = {} as FormErrors<T>;
+			this.errors = {} as FormErrors<T, E>;
 		},
 	};
 }


### PR DESCRIPTION
## Summary

Add an optional second type parameter `E extends string = never` to `FormErrors` and propagate it through the entire type chain (`ValidationResult`, `FieldValidationResult`, `FormValidator`, `Form`, `createFormValidator`, `createForm`, and enhance handlers). This allows users to declare additional error keys for custom validation paths (e.g., Zod's `.refine()` with a `path` that does not correspond to any schema field) without polluting the schema with dummy fields.

## Related Issue

#7

## Changes

- **`src/core/validator.ts`**: Add `E extends string = never` type parameter to `FormErrors`, `ValidationResult`, `FieldValidationResult`, `FormValidator`, and `createFormValidator`. Update `validateField` and `mergeFieldErrors` to accept `(keyof T & string) | E` as the field parameter.
- **`src/form/form.ts`**: Propagate `E` through `Form` type and `createForm` function.
- **`src/enhance/enhance.ts`**: Propagate `E` through `EnhanceHandlerOptions` and `createEnhanceHandler`.
- **`src/enhance/enhance-form.ts`**: Propagate `E` through `buildEnhanceHandler`.
- **`src/core/validator.test.ts`**: Add 6 test cases for custom error keys covering `validate`, `validateField`, `mergeFieldErrors`, and `parseErrors`.
- **`src/form/form.test.ts`**: Add 3 test cases for `createForm` with custom error keys covering `validate`, error clearing, and `reset`.

## Diff Details

```diff
// Key type change — FormErrors now accepts optional extra keys
-export type FormErrors<T extends Record<string, unknown> = Record<string, unknown>> = {
+export type FormErrors<T extends Record<string, unknown> = Record<string, unknown>, E extends string = never> = {
   [K in keyof T]?: string[];
 } & {
   _form?: string[];
+} & {
+  [K in E]?: string[];
 };

// validateField and mergeFieldErrors now accept custom keys
-validateField: (field: keyof T & string, ...) => ...
+validateField: (field: (keyof T & string) | E, ...) => ...

// Usage (from tests):
const validator = createFormValidator<GroupForm, "_kbGroup">(groupSchema);
const form = createForm<GroupForm, "_kbGroup">(groupSchema, initial);
// form.errors._kbGroup is now type-safe
```

---
Generated with [Claude Code](https://claude.com/claude-code)
